### PR TITLE
Fix build failure with Caddy v2.10.2 requiring Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ COPY --from=caddy:builder /usr/bin/xcaddy /usr/bin/xcaddy
 # CGO must be enabled for C bindings, and set build flags for optimization
 ENV CGO_ENABLED=1 XCADDY_SETCAP=1 XCADDY_GO_BUILD_FLAGS='-ldflags="-w -s" -trimpath'
 
+# Allow Go toolchain auto-upgrade to handle newer Go version requirements
+ENV GOTOOLCHAIN=auto
+
 # Build FrankenPHP with xcaddy, including necessary modules
 # --with allows adding external modules to the build
 RUN xcaddy build \


### PR DESCRIPTION
## Summary
- Adds `ENV GOTOOLCHAIN=auto` to the Dockerfile to fix build failures caused by Caddy v2.10.2 requiring Go 1.25+
- The FrankenPHP builder image uses Go 1.24.3, which was causing the build to fail
- With `GOTOOLCHAIN=auto`, Go automatically downloads and uses the required version (1.25.4)

## Test plan
- [x] Verified Docker build completes successfully with the fix
- [x] Confirmed Go automatically upgrades to 1.25.4 during build
- [x] Build produces a working FrankenPHP binary