### PR TITLE
Improve GitHub Actions workflows with CI triggers and validation

### DIFF
--- a/.github/workflows/docker-vips.yml
+++ b/.github/workflows/docker-vips.yml
@@ -6,9 +6,29 @@ name: Build Docker VIPS Images
 # documentation.
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile.vips-ffi'
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker-vips.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile.vips-ffi'
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker-vips.yml'
   schedule:
-    - cron: "0 6 * * 0" # Every Sunday at midnight UTC
+    - cron: "0 6 * * 0" # Every Sunday at 6 AM UTC
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docker:
@@ -56,14 +76,29 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: ./Dockerfile.vips-ffi
           tags: |
             notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi
             ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-vips-ffi
+            ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:vips-ffi' || '' }}
+            ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:vips-ffi', github.repository_owner) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
           sbom: true
+          load: ${{ github.event_name == 'pull_request' }}
+
+      - name: Smoke test
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi php -m | grep FFI
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi ls -la /usr/src/wordpress | grep wp-config-docker.php
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi dpkg -l | grep libvips

--- a/.github/workflows/docker-vips.yml
+++ b/.github/workflows/docker-vips.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: ./Dockerfile.vips-ffi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,27 @@ name: Build Docker Images
 # documentation.
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker.yml'
   schedule:
     - cron: "0 0 * * 0" # Every Sunday at midnight UTC
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docker:
@@ -56,11 +74,13 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           context: .
           tags: |
             notglossy/frankenpress:php-${{ matrix.php-version }}
             ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}
+            ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:latest' || '' }}
+            ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:latest', github.repository_owner) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -68,3 +88,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
           sbom: true
+          load: ${{ github.event_name == 'pull_request' }}
+
+      - name: Smoke test
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} ls -la /usr/src/wordpress | grep wp-config-docker.php

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           tags: |


### PR DESCRIPTION
## Summary
This PR implements high-priority improvements to the GitHub Actions workflows:

### CI/CD Improvements
- ✅ Added push/PR triggers so builds run automatically on code changes
- ✅ Added path filters to only trigger when relevant files change (Dockerfile, Caddyfile, php.ini, workflows)
- ✅ Added concurrency groups to prevent conflicting simultaneous builds
- ✅ PRs now build locally for testing but don't push to registries

### Tagging Improvements
- ✅ PHP 8.4 builds now also tagged as `latest` (standard workflow)
- ✅ PHP 8.4 VIPS builds now also tagged as `vips-ffi` (VIPS workflow)

### Quality Improvements
- ✅ Added smoke tests that run on PRs to validate images before merge
- ✅ Fixed incorrect cron schedule comment in docker-vips.yml

## Smoke Tests
The PR builds now validate that images work correctly:

**Standard builds test:**
- PHP version matches matrix
- FrankenPHP is installed and working
- WP-CLI is available
- WordPress files are present

**VIPS builds additionally test:**
- FFI extension is enabled
- libvips is installed

## Test plan
- [x] Workflows updated with all improvements
- [x] Path filters configured correctly
- [x] Concurrency groups added
- [x] Smoke tests implemented
- [x] Tag logic verified for PHP 8.4