### PR TITLE
December fixes: Upgrade to FrankenPHP 1.10.1 and Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg-dev \
     libwebp-dev \
     libzip-dev \
-    libmemcached-dev \
     zlib1g-dev
 
 


### PR DESCRIPTION
## Summary
This PR upgrades FrankenPress to FrankenPHP 1.10.1 and Debian Trixie, along with build workflow improvements.

### Changes

1. **Upgrade to FrankenPHP 1.10.1 and Debian Trixie**
   - Updated base image to use FrankenPHP 1.10.1
   - Migrated from Debian Bookworm to Trixie
   - Simplified build process by removing custom builder stage
   - Now uses pre-built FrankenPHP binaries from official image

2. **Fix PR build workflows**
   - Disabled provenance and SBOM attestations for PR builds (they create manifest lists incompatible with --load)
   - Changed PR builds to single platform (linux/amd64) for faster testing
   - Production builds still create multi-platform images with full attestations

3. **Fix Debian Trixie package compatibility**
   - Removed manual `libmemcached-dev` installation
   - Let `install-php-extensions` handle dependencies with correct Trixie package names (e.g., `libmemcachedutil2t64`)
   - Fixes linux/arm/v7 build failures

### Test plan
- [x] PR smoke tests pass (PHP version, FFI, frankenphp, wp-cli, libvips verification)
- [ ] Multi-platform production builds succeed on merge to main
- [ ] All three PHP versions (8.2, 8.3, 8.4) build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)