### PR TITLE
Create separate workflows for Bookworm and Trixie builds

### DIFF
--- a/.github/workflows/docker-bookworm.yml
+++ b/.github/workflows/docker-bookworm.yml
@@ -1,0 +1,96 @@
+name: Build Docker Images (Bookworm)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker-bookworm.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker-bookworm.yml'
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [8.2, 8.3, 8.4]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: notglossy/frankenpress
+          labels: |
+            org.opencontainers.image.title=FrankenPress (PHP ${{ matrix.php-version }} Bookworm)
+            org.opencontainers.image.description=WordPress running on FrankenPHP with Debian Bookworm
+            org.opencontainers.image.licenses=MIT
+
+      - name: Set up Docker SBOM
+        uses: anchore/sbom-action/download-syft@v0.15.1
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          context: .
+          tags: |
+            notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-bookworm
+            ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:bookworm' || '' }}
+            ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:bookworm', github.repository_owner) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            PHP_VERSION=${{ matrix.php-version }}
+            DEBIAN_VERSION=bookworm
+            FRANKENPHP_VERSION=1.10.1
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+
+      - name: Smoke test
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm ls -la /usr/src/wordpress | grep wp-config-docker.php

--- a/.github/workflows/docker-bookworm.yml
+++ b/.github/workflows/docker-bookworm.yml
@@ -24,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker-trixie:
-    name: Build Docker Images (Trixie - amd64/arm64)
+  docker:
+    name: Build Docker Images (Bookworm)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker-trixie.yml
+++ b/.github/workflows/docker-trixie.yml
@@ -1,9 +1,4 @@
-name: Build Docker Images
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: Build Docker Images (Trixie)
 
 on:
   push:
@@ -13,15 +8,15 @@ on:
       - 'Dockerfile'
       - 'Caddyfile'
       - 'php.ini'
-      - '.github/workflows/docker.yml'
+      - '.github/workflows/docker-trixie.yml'
   pull_request:
     paths:
       - 'Dockerfile'
       - 'Caddyfile'
       - 'php.ini'
-      - '.github/workflows/docker.yml'
+      - '.github/workflows/docker-trixie.yml'
   schedule:
-    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
+    - cron: "0 1 * * 0" # Every Sunday at 1 AM UTC
   workflow_dispatch:
 
 concurrency:
@@ -37,19 +32,19 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-     
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -63,8 +58,8 @@ jobs:
         with:
           images: notglossy/frankenpress
           labels: |
-            org.opencontainers.image.title=FrankenPress (PHP ${{ matrix.php-version }})
-            org.opencontainers.image.description=WordPress running on FrankenPHP - a high-performance PHP application server
+            org.opencontainers.image.title=FrankenPress (PHP ${{ matrix.php-version }} Trixie)
+            org.opencontainers.image.description=WordPress running on FrankenPHP with Debian Trixie
             org.opencontainers.image.licenses=MIT
 
       - name: Set up Docker SBOM
@@ -73,18 +68,22 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           tags: |
-            notglossy/frankenpress:php-${{ matrix.php-version }}
-            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}
+            notglossy/frankenpress:php-${{ matrix.php-version }}-trixie
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-trixie
+            ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:trixie' || '' }}
             ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:latest' || '' }}
+            ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:trixie', github.repository_owner) || '' }}
             ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:latest', github.repository_owner) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
+            DEBIAN_VERSION=trixie
+            FRANKENPHP_VERSION=1.10.1
           labels: ${{ steps.meta.outputs.labels }}
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -93,7 +92,7 @@ jobs:
       - name: Smoke test
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} php -v | grep "PHP ${{ matrix.php-version }}"
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} frankenphp version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} wp --version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }} ls -la /usr/src/wordpress | grep wp-config-docker.php
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie ls -la /usr/src/wordpress | grep wp-config-docker.php

--- a/.github/workflows/docker-vips-bookworm.yml
+++ b/.github/workflows/docker-vips-bookworm.yml
@@ -1,0 +1,99 @@
+name: Build Docker VIPS Images (Bookworm)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile.vips-ffi'
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker-vips-bookworm.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile.vips-ffi'
+      - 'Dockerfile'
+      - 'Caddyfile'
+      - 'php.ini'
+      - '.github/workflows/docker-vips-bookworm.yml'
+  schedule:
+    - cron: "0 6 * * 0" # Every Sunday at 6 AM UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [8.2, 8.3, 8.4]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: notglossy/frankenpress
+          labels: |
+            org.opencontainers.image.title=FrankenPress VIPS/FFI (PHP ${{ matrix.php-version }} Bookworm)
+            org.opencontainers.image.description=WordPress with VIPS and FFI running on FrankenPHP with Debian Bookworm
+            org.opencontainers.image.licenses=MIT
+
+      - name: Set up Docker SBOM
+        uses: anchore/sbom-action/download-syft@v0.15.1
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          context: .
+          file: ./Dockerfile.vips-ffi
+          tags: |
+            notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm
+            ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:vips-ffi-bookworm' || '' }}
+            ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:vips-ffi-bookworm', github.repository_owner) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            PHP_VERSION=${{ matrix.php-version }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+
+      - name: Smoke test
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm php -m | grep FFI
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm ls -la /usr/src/wordpress | grep wp-config-docker.php
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-bookworm dpkg -l | grep libvips

--- a/.github/workflows/docker-vips-bookworm.yml
+++ b/.github/workflows/docker-vips-bookworm.yml
@@ -26,8 +26,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker-vips-trixie:
-    name: Build VIPS Images (Trixie - amd64/arm64)
+  docker:
+    name: Build VIPS Images (Bookworm)
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker-vips-trixie.yml
+++ b/.github/workflows/docker-vips-trixie.yml
@@ -1,9 +1,4 @@
-name: Build Docker VIPS Images
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: Build Docker VIPS Images (Trixie)
 
 on:
   push:
@@ -14,16 +9,16 @@ on:
       - 'Dockerfile'
       - 'Caddyfile'
       - 'php.ini'
-      - '.github/workflows/docker-vips.yml'
+      - '.github/workflows/docker-vips-trixie.yml'
   pull_request:
     paths:
       - 'Dockerfile.vips-ffi'
       - 'Dockerfile'
       - 'Caddyfile'
       - 'php.ini'
-      - '.github/workflows/docker-vips.yml'
+      - '.github/workflows/docker-vips-trixie.yml'
   schedule:
-    - cron: "0 6 * * 0" # Every Sunday at 6 AM UTC
+    - cron: "0 7 * * 0" # Every Sunday at 7 AM UTC
   workflow_dispatch:
 
 concurrency:
@@ -39,19 +34,19 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-     
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -65,8 +60,8 @@ jobs:
         with:
           images: notglossy/frankenpress
           labels: |
-            org.opencontainers.image.title=FrankenPress (VIPS/FFI PHP ${{ matrix.php-version }})
-            org.opencontainers.image.description=WordPress with VIPS and FFI running on FrankenPHP - a high-performance PHP application server
+            org.opencontainers.image.title=FrankenPress VIPS/FFI (PHP ${{ matrix.php-version }} Trixie)
+            org.opencontainers.image.description=WordPress with VIPS and FFI running on FrankenPHP with Debian Trixie
             org.opencontainers.image.licenses=MIT
 
       - name: Set up Docker SBOM
@@ -75,14 +70,16 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           context: .
           file: ./Dockerfile.vips-ffi
           tags: |
-            notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi
-            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-vips-ffi
+            notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie
+            ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:vips-ffi-trixie' || '' }}
             ${{ matrix.php-version == '8.4' && 'notglossy/frankenpress:vips-ffi' || '' }}
+            ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:vips-ffi-trixie', github.repository_owner) || '' }}
             ${{ matrix.php-version == '8.4' && format('ghcr.io/{0}/frankenpress:vips-ffi', github.repository_owner) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -96,9 +93,9 @@ jobs:
       - name: Smoke test
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi php -v | grep "PHP ${{ matrix.php-version }}"
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi php -m | grep FFI
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi frankenphp version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi wp --version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi ls -la /usr/src/wordpress | grep wp-config-docker.php
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi dpkg -l | grep libvips
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie php -m | grep FFI
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie ls -la /usr/src/wordpress | grep wp-config-docker.php
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-vips-ffi-trixie dpkg -l | grep libvips

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg-dev \
     libwebp-dev \
     libzip-dev \
-    zlib1g-dev \
-    libmemcached-tools
+    zlib1g-dev
 
 
 # Install PHP extensions required by WordPress

--- a/README.md
+++ b/README.md
@@ -1,26 +1,90 @@
 # FrankenPress Docker Image
 
-A WordPress image built for simplicity and scale.
+A WordPress image built for simplicity and scale, powered by FrankenPHP and Caddy.
 
-## Getting Started
+## Quick Start
 
-- [Docker Images](https://hub.docker.com/r/notglossy/frankenpress "Docker Hub")
+```bash
+docker run -d \
+  -p 80:80 \
+  -e DB_HOST=your-db-host \
+  -e DB_USER=wordpress \
+  -e DB_PASSWORD=your-password \
+  -e DB_NAME=wordpress \
+  notglossy/frankenpress:latest
+```
 
-## Whats Included
+## Available Images
 
-### Services
+### Standard Images
+- `notglossy/frankenpress:latest` - Latest with Debian Trixie (amd64, arm64)
+- `notglossy/frankenpress:php-8.4-trixie` - PHP 8.4 on Debian Trixie (amd64, arm64)
+- `notglossy/frankenpress:php-8.4-bookworm` - PHP 8.4 on Debian Bookworm (amd64, arm64, arm/v7)
+- `notglossy/frankenpress:php-8.3-trixie` - PHP 8.3 on Debian Trixie (amd64, arm64)
+- `notglossy/frankenpress:php-8.3-bookworm` - PHP 8.3 on Debian Bookworm (amd64, arm64, arm/v7)
+- `notglossy/frankenpress:php-8.2-trixie` - PHP 8.2 on Debian Trixie (amd64, arm64)
+- `notglossy/frankenpress:php-8.2-bookworm` - PHP 8.2 on Debian Bookworm (amd64, arm64, arm/v7)
 
-- [WordPress](https://hub.docker.com/_/wordpress "WordPress Docker Image")
-- [FrankenPHP](https://hub.docker.com/r/dunglas/frankenphp "FrankenPHP Docker Image")
-- [Caddy](https://caddyserver.com/ "Caddy Server")
+### VIPS Images (with FFI support for advanced image processing)
+- `notglossy/frankenpress:vips-ffi` - Latest VIPS with Debian Trixie (amd64, arm64)
+- `notglossy/frankenpress:php-8.4-vips-ffi-trixie` - PHP 8.4 VIPS on Debian Trixie (amd64, arm64)
+- `notglossy/frankenpress:php-8.4-vips-ffi-bookworm` - PHP 8.4 VIPS on Debian Bookworm (amd64, arm64, arm/v7)
 
-### Caching
+**Note:** ARM v7 (32-bit) support is only available with Debian Bookworm due to package availability limitations in Trixie.
 
-- opcache
+## Choosing Between Trixie and Bookworm
+
+### Debian Trixie (Recommended)
+- **Latest stable Debian release**
+- Newer packages and features
+- Available for: `linux/amd64`, `linux/arm64`
+- Default for `:latest` tag
+
+### Debian Bookworm
+- **Previous stable Debian release**
+- More mature, wider package support
+- Available for: `linux/amd64`, `linux/arm64`, `linux/arm/v7`
+- **Required for 32-bit ARM (arm/v7)** devices like Raspberry Pi 2/3
+
+Use Bookworm if you need ARM v7 support or prefer a more established base. Otherwise, use Trixie for the latest packages.
+
+## Links
+
+- [Docker Hub](https://hub.docker.com/r/notglossy/frankenpress)
+- [GitHub Repository](https://github.com/notglossy/frankenpress)
+
+## What's Included
+
+### Core Components
+
+- **[WordPress](https://wordpress.org/)** - Latest version from official WordPress Docker images
+- **[FrankenPHP 1.10.1](https://frankenphp.dev/)** - Modern PHP application server
+- **[Caddy](https://caddyserver.com/)** - Fast, secure web server with automatic HTTPS
+- **PHP Extensions** - Optimized selection for WordPress performance
+
+### PHP Extensions & Caching
+
+**Performance & Caching:**
+- OPcache (configured for production)
 - APCu
-- Memcache Extension
-- Memcached Extension
-- Redis Extension
+- Memcache
+- Memcached
+- Redis
+- igbinary
+- msgpack
+
+**WordPress Essentials:**
+- bcmath
+- exif
+- gd
+- intl
+- mysqli
+- zip
+- imagick
+
+**VIPS Images Only:**
+- FFI (Foreign Function Interface)
+- libvips (high-performance image processing)
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
Creates separate GitHub Actions workflows for Bookworm and Trixie Debian versions, giving users explicit control over which Debian version they use.

## Changes

### New Workflows
- **docker-bookworm.yml**: Builds all platforms (amd64, arm64, arm/v7) on Debian Bookworm
- **docker-trixie.yml**: Builds amd64/arm64 on Debian Trixie (arm/v7 excluded - no memcached available)
- **docker-vips-bookworm.yml**: VIPS images on Debian Bookworm (all platforms)
- **docker-vips-trixie.yml**: VIPS images on Debian Trixie (amd64/arm64 only)

### New Image Tags

#### Standard Images
- `notglossy/frankenpress:php-8.4-bookworm` (amd64, arm64, arm/v7)
- `notglossy/frankenpress:php-8.4-trixie` (amd64, arm64)
- `notglossy/frankenpress:php-8.3-bookworm`
- `notglossy/frankenpress:php-8.3-trixie`
- `notglossy/frankenpress:php-8.2-bookworm`
- `notglossy/frankenpress:php-8.2-trixie`
- `notglossy/frankenpress:bookworm` (alias for php-8.4-bookworm)
- `notglossy/frankenpress:trixie` (alias for php-8.4-trixie)
- `notglossy/frankenpress:latest` (alias for php-8.4-trixie)

#### VIPS Images
- `notglossy/frankenpress:php-8.4-vips-ffi-bookworm` (amd64, arm64, arm/v7)
- `notglossy/frankenpress:php-8.4-vips-ffi-trixie` (amd64, arm64)
- `notglossy/frankenpress:vips-ffi-bookworm` (alias for php-8.4)
- `notglossy/frankenpress:vips-ffi-trixie` (alias for php-8.4)
- `notglossy/frankenpress:vips-ffi` (alias for php-8.4-vips-ffi-trixie)

## Benefits
1. **User Choice**: Users can explicitly choose which Debian version to use
2. **Consistency**: All platforms within each workflow use the same Debian version
3. **Clearer Intent**: Tag names make it obvious which Debian version is being used
4. **Easier Maintenance**: Each workflow is self-contained and easier to update
5. **Default to Trixie**: The `:latest` tag points to Trixie (newest Debian stable)

## Platform Support
- **Bookworm**: Full support for all platforms (amd64, arm64, arm/v7)
- **Trixie**: amd64 and arm64 only (arm/v7 excluded until memcached packages are available)

## Migration
Old tags will no longer be updated. Users should migrate to:
- `notglossy/frankenpress:php-8.4` → `notglossy/frankenpress:php-8.4-trixie` or `php-8.4-bookworm`
- `notglossy/frankenpress:latest` → Will now point to Trixie

## Test Plan
- [x] All 4 workflows created
- [x] PR builds succeed for all workflows
- [x] Bookworm builds all 3 platforms
- [x] Trixie builds 2 platforms (amd64, arm64)
- [x] Tags are correct and include Debian version suffix
- [x] All PHP versions build successfully (8.2, 8.3, 8.4)