### PR TITLE
Simplify workflows and add supply chain attestations

### DIFF
--- a/.github/workflows/docker-bookworm.yml
+++ b/.github/workflows/docker-bookworm.yml
@@ -33,8 +33,6 @@ jobs:
         # Split platforms to use native runners (amd64 on x64, arm64/armv7 on ARM)
         platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64", "linux/arm/v7"]') }}
       fail-fast: false
-    outputs:
-      php-versions: ${{ toJSON(matrix.php-version) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +59,8 @@ jobs:
           images: |
             notglossy/frankenpress
             ghcr.io/${{ github.repository_owner }}/frankenpress
+          tags: |
+            type=raw,value=php-${{ matrix.php-version }}-bookworm-${{ matrix.platform == 'linux/amd64' && 'amd64' || matrix.platform == 'linux/arm64' && 'arm64' || 'armv7' }}
           labels: |
             org.opencontainers.image.title=FrankenPress (PHP ${{ matrix.php-version }} Bookworm)
             org.opencontainers.image.description=WordPress running on FrankenPHP with Debian Bookworm
@@ -68,98 +68,41 @@ jobs:
           flavor: |
             latest=false
 
-      - name: Build and push by digest
-        id: build
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
           context: .
-          outputs: type=image,name=notglossy/frankenpress,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: |
             type=gha,scope=${{ matrix.platform }}-${{ matrix.php-version }}
-            type=registry,ref=notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm
+            type=registry,ref=notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-${{ matrix.platform == 'linux/amd64' && 'amd64' || matrix.platform == 'linux/arm64' && 'arm64' || 'armv7' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}-${{ matrix.php-version }}
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
             DEBIAN_VERSION=bookworm
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
-          sbom: false
-
-      - name: Build and push to GHCR by digest
-        id: build-ghcr
-        uses: docker/build-push-action@v6
-        with:
-          platforms: ${{ matrix.platform }}
-          context: .
-          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/frankenpress,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}-${{ matrix.php-version }}
-          build-args: |
-            PHP_VERSION=${{ matrix.php-version }}
-            DEBIAN_VERSION=bookworm
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
-          sbom: false
-
-      - name: Export digests
-        if: github.event_name != 'pull_request'
-        run: |
-          mkdir -p /tmp/digests/dockerhub/${{ matrix.php-version }}
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/dockerhub/${{ matrix.php-version }}/${digest#sha256:}"
-
-          mkdir -p /tmp/digests/ghcr/${{ matrix.php-version }}
-          digest="${{ steps.build-ghcr.outputs.digest }}"
-          touch "/tmp/digests/ghcr/${{ matrix.php-version }}/${digest#sha256:}"
-
-      - name: Upload digest
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.php-version }}-${{ strategy.job-index }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Load image for testing
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
-        with:
-          platforms: ${{ matrix.platform }}
-          context: .
-          load: true
-          tags: notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}-${{ matrix.php-version }}
-          build-args: |
-            PHP_VERSION=${{ matrix.php-version }}
-            DEBIAN_VERSION=bookworm
-          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          load: ${{ github.event_name == 'pull_request' }}
 
       - name: Smoke test
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm php -v | grep "PHP ${{ matrix.php-version }}"
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm frankenphp version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm wp --version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm ls -la /usr/src/wordpress | grep wp-config-docker.php
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-amd64 php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-amd64 frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-amd64 wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-amd64 ls -la /usr/src/wordpress | grep wp-config-docker.php
 
-  merge:
+  create-manifests:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
       matrix:
-        php-version: ${{ github.event_name == 'pull_request' && fromJSON('[8.4]') || fromJSON('[8.2, 8.3, 8.4]') }}
+        php-version: [8.2, 8.3, 8.4]
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digests-${{ matrix.php-version }}-*
-          path: /tmp/digests
-          merge-multiple: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -176,21 +119,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest list and push (Docker Hub)
-        working-directory: /tmp/digests/dockerhub/${{ matrix.php-version }}
+      - name: Create multi-arch manifest (Docker Hub)
         run: |
           docker buildx imagetools create \
             -t notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm \
-            ${{ matrix.php-version == '8.4' && '-t notglossy/frankenpress:bookworm' || '' }} \
-            $(printf 'notglossy/frankenpress@sha256:%s ' *)
+            ${{ matrix.php-version == 8.4 && '-t notglossy/frankenpress:bookworm' || '' }} \
+            notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-amd64 \
+            notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-arm64 \
+            notglossy/frankenpress:php-${{ matrix.php-version }}-bookworm-armv7
 
-      - name: Create manifest list and push (GHCR)
-        working-directory: /tmp/digests/ghcr/${{ matrix.php-version }}
+      - name: Create multi-arch manifest (GHCR)
         run: |
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-bookworm \
-            ${{ matrix.php-version == '8.4' && format('-t ghcr.io/{0}/frankenpress:bookworm', github.repository_owner) || '' }} \
-            $(printf 'ghcr.io/${{ github.repository_owner }}/frankenpress@sha256:%s ' *)
+            ${{ matrix.php-version == 8.4 && format('-t ghcr.io/{0}/frankenpress:bookworm', github.repository_owner) || '' }} \
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-bookworm-amd64 \
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-bookworm-arm64 \
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-bookworm-armv7
 
       - name: Inspect image (Docker Hub)
         run: |

--- a/.github/workflows/docker-bookworm.yml
+++ b/.github/workflows/docker-bookworm.yml
@@ -83,8 +83,8 @@ jobs:
             PHP_VERSION=${{ matrix.php-version }}
             DEBIAN_VERSION=bookworm
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
+          provenance: ${{ github.event_name != 'pull_request' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
 
       - name: Smoke test

--- a/.github/workflows/docker-trixie.yml
+++ b/.github/workflows/docker-trixie.yml
@@ -83,8 +83,8 @@ jobs:
             PHP_VERSION=${{ matrix.php-version }}
             DEBIAN_VERSION=trixie
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
+          provenance: ${{ github.event_name != 'pull_request' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
 
       - name: Smoke test

--- a/.github/workflows/docker-trixie.yml
+++ b/.github/workflows/docker-trixie.yml
@@ -33,8 +33,6 @@ jobs:
         # Split platforms to use native runners (amd64 on x64, arm64 on ARM)
         platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
       fail-fast: false
-    outputs:
-      php-versions: ${{ toJSON(matrix.php-version) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +59,8 @@ jobs:
           images: |
             notglossy/frankenpress
             ghcr.io/${{ github.repository_owner }}/frankenpress
+          tags: |
+            type=raw,value=php-${{ matrix.php-version }}-trixie-${{ matrix.platform == 'linux/amd64' && 'amd64' || matrix.platform == 'linux/arm64' && 'arm64' || 'armv7' }}
           labels: |
             org.opencontainers.image.title=FrankenPress (PHP ${{ matrix.php-version }} Trixie)
             org.opencontainers.image.description=WordPress running on FrankenPHP with Debian Trixie
@@ -68,98 +68,41 @@ jobs:
           flavor: |
             latest=false
 
-      - name: Build and push by digest
-        id: build
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
           context: .
-          outputs: type=image,name=notglossy/frankenpress,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: |
             type=gha,scope=${{ matrix.platform }}-${{ matrix.php-version }}
-            type=registry,ref=notglossy/frankenpress:php-${{ matrix.php-version }}-trixie
+            type=registry,ref=notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-${{ matrix.platform == 'linux/amd64' && 'amd64' || matrix.platform == 'linux/arm64' && 'arm64' || 'armv7' }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}-${{ matrix.php-version }}
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
             DEBIAN_VERSION=trixie
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
-          sbom: false
-
-      - name: Build and push to GHCR by digest
-        id: build-ghcr
-        uses: docker/build-push-action@v6
-        with:
-          platforms: ${{ matrix.platform }}
-          context: .
-          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/frankenpress,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}-${{ matrix.php-version }}
-          build-args: |
-            PHP_VERSION=${{ matrix.php-version }}
-            DEBIAN_VERSION=trixie
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
-          sbom: false
-
-      - name: Export digests
-        if: github.event_name != 'pull_request'
-        run: |
-          mkdir -p /tmp/digests/dockerhub/${{ matrix.php-version }}
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/dockerhub/${{ matrix.php-version }}/${digest#sha256:}"
-
-          mkdir -p /tmp/digests/ghcr/${{ matrix.php-version }}
-          digest="${{ steps.build-ghcr.outputs.digest }}"
-          touch "/tmp/digests/ghcr/${{ matrix.php-version }}/${digest#sha256:}"
-
-      - name: Upload digest
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.php-version }}-${{ strategy.job-index }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Load image for testing
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
-        with:
-          platforms: ${{ matrix.platform }}
-          context: .
-          load: true
-          tags: notglossy/frankenpress:php-${{ matrix.php-version }}-trixie
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}-${{ matrix.php-version }}
-          build-args: |
-            PHP_VERSION=${{ matrix.php-version }}
-            DEBIAN_VERSION=trixie
-          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          load: ${{ github.event_name == 'pull_request' }}
 
       - name: Smoke test
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie php -v | grep "PHP ${{ matrix.php-version }}"
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie frankenphp version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie wp --version
-          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie ls -la /usr/src/wordpress | grep wp-config-docker.php
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-amd64 php -v | grep "PHP ${{ matrix.php-version }}"
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-amd64 frankenphp version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-amd64 wp --version
+          docker run --rm notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-amd64 ls -la /usr/src/wordpress | grep wp-config-docker.php
 
-  merge:
+  create-manifests:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
       matrix:
-        php-version: ${{ github.event_name == 'pull_request' && fromJSON('[8.4]') || fromJSON('[8.2, 8.3, 8.4]') }}
+        php-version: [8.2, 8.3, 8.4]
     steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          pattern: digests-${{ matrix.php-version }}-*
-          path: /tmp/digests
-          merge-multiple: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -176,21 +119,21 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest list and push (Docker Hub)
-        working-directory: /tmp/digests/dockerhub/${{ matrix.php-version }}
+      - name: Create multi-arch manifest (Docker Hub)
         run: |
           docker buildx imagetools create \
             -t notglossy/frankenpress:php-${{ matrix.php-version }}-trixie \
-            ${{ matrix.php-version == '8.4' && '-t notglossy/frankenpress:trixie -t notglossy/frankenpress:latest' || '' }} \
-            $(printf 'notglossy/frankenpress@sha256:%s ' *)
+            ${{ matrix.php-version == 8.4 && '-t notglossy/frankenpress:trixie -t notglossy/frankenpress:latest' || '' }} \
+            notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-amd64 \
+            notglossy/frankenpress:php-${{ matrix.php-version }}-trixie-arm64
 
-      - name: Create manifest list and push (GHCR)
-        working-directory: /tmp/digests/ghcr/${{ matrix.php-version }}
+      - name: Create multi-arch manifest (GHCR)
         run: |
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-trixie \
-            ${{ matrix.php-version == '8.4' && format('-t ghcr.io/{0}/frankenpress:trixie -t ghcr.io/{0}/frankenpress:latest', github.repository_owner) || '' }} \
-            $(printf 'ghcr.io/${{ github.repository_owner }}/frankenpress@sha256:%s ' *)
+            ${{ matrix.php-version == 8.4 && format('-t ghcr.io/{0}/frankenpress:trixie -t ghcr.io/{0}/frankenpress:latest', github.repository_owner) || '' }} \
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-trixie-amd64 \
+            ghcr.io/${{ github.repository_owner }}/frankenpress:php-${{ matrix.php-version }}-trixie-arm64
 
       - name: Inspect image (Docker Hub)
         run: |


### PR DESCRIPTION
## Summary
Simplifies the Docker build workflows and adds SBOM/provenance attestations to satisfy Docker Hub's supply chain security requirements.

## Changes

### Workflow Simplification
- **Removed**: Complex digest-based build approach with separate export/merge steps
- **Added**: Simple platform-specific tags (e.g., `php-8.4-trixie-amd64`, `php-8.4-trixie-arm64`)
- **Added**: Separate manifest creation job to combine platforms into multi-arch images

### Supply Chain Security
- **Enabled**: `provenance: true` and `sbom: true` for all builds
- **Result**: Images now include cryptographic attestations for supply chain verification
- **Fixes**: Docker Hub warning about missing supply chain attestation(s)

### Performance Maintained
- ✅ Native ARM builds still run on `ubuntu-24.04-arm` runners
- ✅ Platform-scoped caching preserved
- ✅ No QEMU emulation overhead

### Workflow Structure
**Before**: Digest-based → Complex export → Artifact upload → Merge
**After**: Tagged builds → Simple manifest creation

This approach matches the frankenpress-src repository and is simpler to understand and maintain.

## Test Plan
- [ ] Verify workflows trigger on PR
- [ ] Confirm builds run on correct runners (AMD64 on ubuntu-latest, ARM on ubuntu-24.04-arm)
- [ ] Validate smoke tests pass
- [ ] Check that SBOM and provenance are attached to images
- [ ] Verify multi-arch manifests are created correctly

## Breaking Changes
None - the final multi-arch image tags remain the same:
- `php-8.4-trixie`, `trixie`, `latest`
- `php-8.4-bookworm`, `bookworm`

Platform-specific tags are now also available:
- `php-8.4-trixie-amd64`, `php-8.4-trixie-arm64`
- `php-8.4-bookworm-amd64`, `php-8.4-bookworm-arm64`, `php-8.4-bookworm-armv7`