### PR TITLE
Fix vips-ffi builds to use correct Debian-versioned base images

### DIFF
--- a/.github/workflows/docker-vips-bookworm.yml
+++ b/.github/workflows/docker-vips-bookworm.yml
@@ -87,6 +87,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
+            DEBIAN_VERSION=bookworm
           labels: ${{ steps.meta.outputs.labels }}
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
           sbom: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-vips-trixie.yml
+++ b/.github/workflows/docker-vips-trixie.yml
@@ -88,6 +88,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
+            DEBIAN_VERSION=trixie
           labels: ${{ steps.meta.outputs.labels }}
           provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
           sbom: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile.vips-ffi
+++ b/Dockerfile.vips-ffi
@@ -1,10 +1,11 @@
 # Define build arguments that can be overridden at build time
 ARG WORDPRESS_VERSION=latest
 ARG PHP_VERSION=8.3
+ARG DEBIAN_VERSION=trixie
 
 
 # First stage: builder - used to build FrankenPHP with custom modules
-FROM ghcr.io/notglossy/frankenpress:php-${PHP_VERSION}
+FROM ghcr.io/notglossy/frankenpress:php-${PHP_VERSION}-${DEBIAN_VERSION}
 
 USER root
 


### PR DESCRIPTION
## Summary
- The vips-ffi Dockerfile was referencing `php-{version}` base image tags (e.g. `php-8.4`) which don't exist — only Debian-suffixed tags like `php-8.4-trixie` and `php-8.4-bookworm` are created by the base workflows
- Added a `DEBIAN_VERSION` build arg to `Dockerfile.vips-ffi` and pass it from each workflow so trixie and bookworm vips-ffi builds pull the correct base image

## Test plan
- [x] Verify the trixie vips-ffi CI build succeeds with the correct `php-X.Y-trixie` base image
- [x] Verify the bookworm vips-ffi CI build succeeds with the correct `php-X.Y-bookworm` base image
- [x] Confirm smoke tests pass (PHP version, FFI module, libvips present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)